### PR TITLE
Update default.rb

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -11,7 +11,11 @@ end
 
 service 'incrond' do
   service_name node['incron']['service_name']
-  supports :status => true, :restart => true, :reload => true
+  if platform_family?('centos') && node['platform_version'].to_f >= 7.0
+    supports :status => true, :restart => true, :reload => false
+  else
+    supports :status => true, :restart => true, :reload => true
+  end
   action [:enable, :start]
 end
 
@@ -19,5 +23,9 @@ template '/etc/incron.conf' do
   source 'incron.conf.erb'
   mode '0644'
   action :create
-  notifies :reload, 'service[incrond]'
+  if platform_family?('centos') && node['platform_version'].to_f >= 7.0
+    notifies :restart, 'service[incrond]'
+  else
+    notifies :reload, 'service[incrond]'
+  end
 end


### PR DESCRIPTION
test-kitchen failed on converge for me on CentOS 7, seems that reload doesn't work for it.

[root@default-centos-70 ~]# systemctl reload incrond
Failed to issue method call: Job type reload is not applicable for unit incrond.service.