### PR TITLE
Notify Service Restarts in LWRPs for EL7

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,6 +2,12 @@ default['incron']['allowed_users'] = ['root']
 default['incron']['denied_users'] = []
 default['incron']['editor'] = 'vim'
 
+if node['platform_family'] == 'rhel' && node['platform_version'].to_f >= 7.0
+  default['incron']['reload_method'] = :restart
+else
+  default['incron']['reload_method'] = :reload
+end
+
 case node['platform_family']
 when 'debian'
   default['incron']['service_name'] = 'incron'

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer       'David Radcliffe'
 maintainer_email 'radcliffe.david@gmail.com'
 license          'MIT'
 description      'Installs and configures incron'
-version          '0.3.4'
+version          '0.3.5'
 
 recipe 'incron',  'Install incron package and starts the service'
 

--- a/providers/d.rb
+++ b/providers/d.rb
@@ -14,7 +14,7 @@ action :create do
       :command => new_resource.command
     )
     action :create
-    notifies :reload, 'service[incrond]'
+    notifies node['incron']['reload_method'], 'service[incrond]'
   end
   new_resource.updated_by_last_action(t.updated_by_last_action?)
 
@@ -24,7 +24,7 @@ action :delete do
 
   file "/etc/incron.d/#{new_resource.name}" do
     action :delete
-    notifies :reload, 'service[incrond]'
+    notifies node['incron']['reload_method'], 'service[incrond]'
   end
 
 end

--- a/providers/user.rb
+++ b/providers/user.rb
@@ -39,7 +39,7 @@ def update_config(list_type = 'allow')
       :users => users
     )
     action :create
-    notifies :reload, 'service[incrond]'
+    notifies node['incron']['reload_method'], 'service[incrond]'
   end
 
   new_resource.updated_by_last_action(t.updated_by_last_action?)

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -9,11 +9,9 @@ package 'incron' do
   action :install
 end
 
-centos7 = platform_family?('centos') && node['platform_version'].to_f >= 7.0
-
 service 'incrond' do
   service_name node['incron']['service_name']
-  supports :status => true, :restart => true, :reload => !centos7
+  supports :status => true, :restart => true, :reload => node['incron']['reload_method'] == :reload
   action [:enable, :start]
 end
 
@@ -21,9 +19,5 @@ template '/etc/incron.conf' do
   source 'incron.conf.erb'
   mode '0644'
   action :create
-  if centos7
-    notifies :restart, 'service[incrond]'
-  else
-    notifies :reload, 'service[incrond]'
-  end
+  notifies node['incron']['reload_method'], 'service[incrond]'
 end

--- a/spec/unit/providers/d_spec.rb
+++ b/spec/unit/providers/d_spec.rb
@@ -8,4 +8,16 @@ describe 'incron_d' do
     expect(chef_run).to render_file('/etc/incron.d/notify_home_changes').with_content('/home IN_MODIFY /usr/local/bin/abcd')
   end
 
+ it 'should reload incrond' do
+   expect(chef_run.template('/etc/incron.d/notify_home_changes')).to notify('service[incrond]').to(:reload)
+ end
+
+  context 'on an el 7 system' do
+    let(:chef_run) { ChefSpec::SoloRunner.new(:platform => 'redhat', :version  => '7.0', step_into: ['incron_d']).converge('incron_spec::simple') }
+
+    it 'should restart incrond' do
+      expect(chef_run.template('/etc/incron.d/notify_home_changes')).to notify('service[incrond]').to(:restart)
+    end
+  end
+
 end

--- a/spec/unit/providers/d_spec.rb
+++ b/spec/unit/providers/d_spec.rb
@@ -8,9 +8,9 @@ describe 'incron_d' do
     expect(chef_run).to render_file('/etc/incron.d/notify_home_changes').with_content('/home IN_MODIFY /usr/local/bin/abcd')
   end
 
- it 'should reload incrond' do
-   expect(chef_run.template('/etc/incron.d/notify_home_changes')).to notify('service[incrond]').to(:reload)
- end
+  it 'should reload incrond' do
+    expect(chef_run.template('/etc/incron.d/notify_home_changes')).to notify('service[incrond]').to(:reload)
+  end
 
   context 'on an el 7 system' do
     let(:chef_run) { ChefSpec::SoloRunner.new(:platform => 'redhat', :version  => '7.0', step_into: ['incron_d']).converge('incron_spec::simple') }


### PR DESCRIPTION
Hi there,

I was trying to use the LWRPs on a centos 7 install, but was unable to because the service didn't support a `:reload` action. This PR parameterizes the restart method as an attribute and then uses that wherever service reloads/restarts are notified.